### PR TITLE
--with-default-names not supported when installing grep with Homebrew 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 ## Zalenium one-liner installer
 
-    curl -sSL https://raw.githubusercontent.com/dosel/t/i/p | bash
+    curl -sSL https://raw.githubusercontent.com/antlong/t/i/p | bash
 
 ## Install and start
 
-    curl -sSL https://raw.githubusercontent.com/dosel/t/i/p | bash -s start
+    curl -sSL https://raw.githubusercontent.com/antlong/t/i/p | bash -s start
 
 ## Install and start with latest Selenium 3
 
-    curl -sSL https://raw.githubusercontent.com/dosel/t/i/p | bash -s 3 start
+    curl -sSL https://raw.githubusercontent.com/antlong/t/i/p | bash -s 3 start
 
 ## Install and start with latest Selenium 2
 
-    curl -sSL https://raw.githubusercontent.com/dosel/t/i/p | bash -s 2 start
+    curl -sSL https://raw.githubusercontent.com/antlong/t/i/p | bash -s 2 start
 
 ## Install and start a specific version
 
-    curl -sSL https://raw.githubusercontent.com/dosel/t/i/p | bash -s 3.0.1a start
+    curl -sSL https://raw.githubusercontent.com/antlong/t/i/p | bash -s 3.0.1a start
 
 ## Tiny smoke python selenium test
 
@@ -25,4 +25,4 @@
 
 ## Cleanup
 
-    curl -sSL https://raw.githubusercontent.com/dosel/t/i/p | bash -s stop
+    curl -sSL https://raw.githubusercontent.com/antlong/t/i/p | bash -s stop

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 ## Zalenium one-liner installer
 
-    curl -sSL https://raw.githubusercontent.com/antlong/t/i/p | bash
+    curl -sSL https://raw.githubusercontent.com/dosel/t/i/p | bash
 
 ## Install and start
 
-    curl -sSL https://raw.githubusercontent.com/antlong/t/i/p | bash -s start
+    curl -sSL https://raw.githubusercontent.com/dosel/t/i/p | bash -s start
 
 ## Install and start with latest Selenium 3
 
-    curl -sSL https://raw.githubusercontent.com/antlong/t/i/p | bash -s 3 start
+    curl -sSL https://raw.githubusercontent.com/dosel/t/i/p | bash -s 3 start
 
 ## Install and start with latest Selenium 2
 
-    curl -sSL https://raw.githubusercontent.com/antlong/t/i/p | bash -s 2 start
+    curl -sSL https://raw.githubusercontent.com/dosel/t/i/p | bash -s 2 start
 
 ## Install and start a specific version
 
-    curl -sSL https://raw.githubusercontent.com/antlong/t/i/p | bash -s 3.0.1a start
+    curl -sSL https://raw.githubusercontent.com/dosel/t/i/p | bash -s 3.0.1a start
 
 ## Tiny smoke python selenium test
 
@@ -25,4 +25,4 @@
 
 ## Cleanup
 
-    curl -sSL https://raw.githubusercontent.com/antlong/t/i/p | bash -s stop
+    curl -sSL https://raw.githubusercontent.com/dosel/t/i/p | bash -s stop

--- a/p
+++ b/p
@@ -19,7 +19,11 @@ function mtimeout() {
 function please_install_gnu_grep() {
     echo "GNU grep is not installed, please install with:"
     echo "  brew tap homebrew/dupes"
-    echo "  brew install grep --with-default-names"
+    B_VERSION=$(IFS=" " read -r -a array <<< "$(brew -v)" && echo "${array[1]}" && [[ ${array[1]} == 2* ]])
+    if [ $B_VERSION == 1.* ]; then
+      echo "  brew install grep --with-default-names"
+    else
+      echo "  brew install grep"
     echo ""
     exit 16
 }


### PR DESCRIPTION
Homebrew 2.x dropped support for installing grep --with-default-names, so the argument has to be removed on platforms running v2. I left it for users running 1.x since there wasn't a need to change it. 